### PR TITLE
Fixes wide images from overflowing in FF and IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightbox",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Image lightbox",
   "main": "lightbox.js",
   "scripts": {

--- a/sass/lightbox.scss
+++ b/sass/lightbox.scss
@@ -150,7 +150,7 @@ $button-padding: 40px;
 } // #lightbox-inner-wrap
 
 #lightbox-img-wrap {
-  display: inline-block;
+  display: block;
   height: 100%;
   position: relative;
 }


### PR DESCRIPTION
https://github.com/adobe-community/issues/issues/7503

Tested in FF45 and IE11:

![screen shot 2016-03-24 at 4 31 06 pm](https://cloud.githubusercontent.com/assets/916262/14030453/012f5f54-f1de-11e5-89e3-0030b83c1288.png)


![screen shot 2016-03-24 at 4 32 02 pm](https://cloud.githubusercontent.com/assets/916262/14030455/03a41e28-f1de-11e5-9e40-58b27b9b2651.png)
