### PR TITLE
Feature/fade out secondary elements

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["behance"]
-}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # OSX os files
 .DS_Store
 .DS_Store?
+npm-debug.log
 
 # SASS
 .sass-cache

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lightbox",
   "version": "3.2.0",
   "description": "Image lightbox",
-  "main": "lightbox.js",
+  "main": "src",
   "scripts": {
     "test": "npm run eslint && npm run karma -- --single-run",
     "eslint": "eslint src/**/*.js test/**/*.js",
@@ -28,6 +28,7 @@
     "babel-loader": "^6.2.5",
     "babel-preset-behance": "^2.0.0",
     "css-loader": "^0.25.0",
+    "es6-shim": "^0.35.1",
     "eslint": "^3.5.0",
     "eslint-plugin-behance": "^1.0.0",
     "eslint-preset-behance": "^4.0.0",

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -1,0 +1,104 @@
+import $ from 'jquery';
+import LightboxImage from './LightboxImage';
+
+const BACKDROP_TEMPLATE = '<div class="js-blocking" id="lightbox-blocking"></div>';
+const ESCAPE_KEYCODE = 27;
+const LEFT_ARROW_KEYCODE = 37;
+const RIGHT_ARROW_KEYCODE = 39;
+
+export default class Lightbox {
+  constructor(options) {
+    const config = Object.assign({
+      context: document.body,
+      imageSelector: '.js-lightbox',
+      imageSrcDataAttr: 'src',
+      bgColor: '#fff',
+      opacity: '0.94'
+    }, options);
+
+    this.fadeTimeInMs = 200;
+    this.$body = $(document.body);
+    this.$blocking = $(BACKDROP_TEMPLATE);
+    this.images = [];
+    this.activeImageId = false;
+    this.isLoading = false;
+    this.isSingle = false;
+    this.$context = $(config.context);
+    this.bgColor = config.bgColor;
+    this.opacity = config.opacity;
+
+    this.$context.find(config.imageSelector).each((i, el) => {
+      const $img = $(el);
+      $img.data('img-id', i).addClass('lightbox-link');
+      this.images[i] = new LightboxImage(this, $img.data(config.imageSrcDataAttr), i);
+    });
+
+    const self = this;
+    this.$context.find(`:not(a) > ${config.imageSelector}`).on('click', function(e) {
+      e.stopPropagation();
+      self.images[$(this).data('img-id')].render();
+    });
+
+    if (this.images.length === 1) {
+      this.isSingle = true;
+    }
+  }
+
+  close() {
+    if (this.isLoading || this.activeImageId === false) {
+      return;
+    }
+
+    this.$body.add(this.$context).off('click.lightbox');
+    this.$activeImage.fadeOut(this.fadeTimeInMs, () => {
+      this.$activeImage.remove();
+      this.$activeImage = null;
+      this.$body.find(this.$blocking).remove();
+      this.$body.removeClass('lightbox-active');
+      this.activeImageId = false;
+    });
+  }
+
+  next() {
+    this.images[(this.images[this.activeImageId + 1]) ? this.activeImageId + 1 : 0].render();
+  }
+
+  prev() {
+    this.images[(this.images[this.activeImageId - 1]) ? this.activeImageId - 1 : this.images.length - 1].render();
+  }
+
+  bind() {
+    this.$body.on('click.lightbox', () => {
+      this.close();
+    });
+
+    $(document).on('keyup.lightbox', (e) => {
+      if (e.keyCode === ESCAPE_KEYCODE) {
+        this.close();
+      }
+    });
+
+    if (this.isSingle) {
+      return;
+    }
+
+    this.$context.on('click.lightbox', '.js-next', (e) => {
+      e.stopPropagation();
+      this.next();
+    });
+
+    this.$context.on('click.lightbox', '.js-prev', (e) => {
+      e.stopPropagation();
+      this.prev();
+    });
+
+    $(document).on('keyup.lightbox', (e) => {
+      if (e.keyCode === LEFT_ARROW_KEYCODE) {
+        this.prev();
+      }
+      else if (e.keyCode === RIGHT_ARROW_KEYCODE) {
+        this.next();
+      }
+    });
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,7 @@ import 'style!../sass/lightbox.scss';
 import Lightbox from './Lightbox';
 
 export default {
-  init: (options) => new Lightbox(options)
+  init(options) {
+    return new Lightbox(options);
+  }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+import 'style!../sass/lightbox.scss';
+import Lightbox from './Lightbox';
+
+export default {
+  init: (options) => new Lightbox(options)
+};

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -9,6 +9,7 @@ module.exports = function(config) {
       'jasmine'
     ],
     files: [
+      require.resolve('es6-shim'),
       'node_modules/jquery/dist/jquery.js',
       'node_modules/jasmine-jquery/lib/jasmine-jquery.js',
       'node_modules/jasmine-fixture/dist/jasmine-fixture.js',

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -31,7 +31,10 @@ module.exports = function(config) {
       module: {
         rules: [{
           test: /\.js$/,
-          loader: 'babel'
+          loader: 'babel',
+          query: {
+            presets: ['behance']
+          }
         }, {
           test: /\.scss$/,
           loader: 'css!sass?includePaths[]=' + bourbonIncludePaths,

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import lightbox from '../../lightbox';
+import lightbox from '../..';
 
 describe('lightbox', function() {
   const FADE_TIME = 200;


### PR DESCRIPTION
This is the first refactoring after introducing the tests. There's still much to be done (like removing the reference to `this.lightbox` in the `LightboxImage`) but I'd like to take do it in small steps. 

- refactored to avoid module scoped state
- refactored to extract classes into their own files
- babel: move presets config into tests to prevent a host (be.net) from using a test-only .babelrc
