### PR TITLE
Hide prev and/or next controls as appropriate

### DIFF
--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -3,5 +3,6 @@ import lightbox from '../../';
 window.lightbox = lightbox.init({
   imageSelector: '.project-image',
   bgColor: '#000',
-  opacity: 0.7
+  opacity: 0.7,
+  isCircular: false
 });

--- a/sass/lightbox.scss
+++ b/sass/lightbox.scss
@@ -110,6 +110,16 @@ $button-padding: 40px;
       opacity: 1;
     }
 
+    &.hidden {
+
+      cursor: default;
+
+      svg {
+        display: none;
+      }
+
+    } // .hidden
+
     svg {
 
       @include calc('top', '50% - 15px');

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -6,7 +6,7 @@ export default class Controller {
     this._$context = $context;
     this._$eventNode = $('<e/>');
     this._$links = this._$context.find(`:not(a) > ${this._props.imageSelector}`);
-    this._slides = this._createSlides(this._$links);
+    this.slides = this._createSlides(this._$links);
     this._bind();
   }
 
@@ -23,8 +23,8 @@ export default class Controller {
   }
 
   open(slideId) {
-    const slide = this._slides[slideId];
-    this._activeSlideId = slide.id;
+    const slide = this.slides[slideId];
+    this.activeSlide = slide;
     this._trigger('open', [slide]);
   }
 
@@ -33,35 +33,21 @@ export default class Controller {
   }
 
   next() {
-    const next = this._slides[this._activeSlideId + 1];
+    const nextId = this.activeSlide.id + 1;
+    const next = this.slides[nextId];
     if (!this._props.isCircular && !next) { return; }
-
     const firstId = 0;
-    const nextId = this._activeSlideId + 1;
-    this._activeSlideId = next ? nextId : firstId;
-    const activeSlide = this._slides[this._activeSlideId];
-
-    this._trigger('next', activeSlide);
+    this.activeSlide = this.slides[next ? nextId : firstId];
+    this._trigger('next', this.activeSlide);
   }
 
   prev() {
-    const prev = this._slides[this._activeSlideId - 1];
+    const prevId = this.activeSlide.id - 1;
+    const prev = this.slides[prevId];
     if (!this._props.isCircular && !prev) { return; }
-
-    const lastId = this._slides.length - 1;
-    const prevId = this._activeSlideId - 1;
-    this._activeSlideId = prev ? prevId : lastId;
-    const activeSlide = this._slides[this._activeSlideId];
-
-    this._trigger('prev', activeSlide);
-  }
-
-  hideExtras() {
-    this._trigger('extrasHidden');
-  }
-
-  showExtras() {
-    this._trigger('extrasShown');
+    const lastId = this.slides.length - 1;
+    this.activeSlide = this.slides[prev ? prevId : lastId];
+    this._trigger('prev', this.activeSlide);
   }
 
   destroy() {
@@ -74,7 +60,7 @@ export default class Controller {
     const self = this;
     this._$links.addClass('lightbox-link').click(function(e) {
       e.stopPropagation();
-      self.open(self._slides.filter(slide => slide.$node.is(this))[0].id);
+      self.open(self.slides.filter(slide => slide.$node.is(this))[0].id);
     });
   }
 

--- a/test/specs/ChromeView.js
+++ b/test/specs/ChromeView.js
@@ -1,0 +1,99 @@
+import $ from 'jquery';
+import ChromeView from '../../src/ChromeView';
+
+const imagePath = id => `/base/test/fixtures/images/img_${id}.png`;
+
+const FIXTURE = `
+  <div id="container">
+    <img data-src="${imagePath(1)}" />
+  </div>
+`;
+const PREV_CLASS = '.js-prev';
+const NEXT_CLASS = '.js-next';
+const HIDDEN_CLASS = 'hidden';
+const expectPrevToBeHidden = () => expect($(PREV_CLASS)).toHaveClass(HIDDEN_CLASS);
+const expectPrevToBeShown = () => expect($(PREV_CLASS)).not.toHaveClass(HIDDEN_CLASS);
+const expectNextToBeHidden = () => expect($(NEXT_CLASS)).toHaveClass(HIDDEN_CLASS);
+const expectNextToBeShown = () => expect($(NEXT_CLASS)).not.toHaveClass(HIDDEN_CLASS);
+
+describe('ChromeView', function() {
+  beforeEach(function() {
+    const fixture = setFixtures(FIXTURE);
+    this.$context = fixture.find('#container');
+    this.controller = jasmine.createSpyObj('controller', [
+      'on', 'off', 'next', 'prev'
+    ]);
+    this.props = {};
+    this.set = (props) => {
+      Object.keys(props).forEach(key => this.props[key] = props[key]);
+      this.$img = this.$context.find('img').first();
+      this.controller.slides = [
+        { id: 0, $node: this.$img },
+        { id: 1, $node: this.$img },
+        { id: 2, $node: this.$img },
+      ];
+      this.view = new ChromeView(this.$context, this.controller, this.props);
+      this.listeners = this.controller.on.calls.first().args[0];
+    };
+    this.set({ imageSrcDataAttr: 'src' });
+  });
+
+  afterEach(function() {
+    this.view.destroy();
+  });
+
+  describe('hide prev & next when only one slide is present', function() {
+    beforeEach(function() {
+      this.assert = () => {
+        this.controller.slides = [{ id: 0, $node: this.$img }];
+        this.listeners.open(this.controller.slides[0]);
+        expectPrevToBeHidden();
+        expectNextToBeHidden();
+      };
+    });
+
+    it('be hidden in circular', function() {
+      this.set({ isCircular: true });
+      this.assert();
+    });
+
+    it('be hidden in non-circular', function() {
+      this.set({ isCircular: false });
+      this.assert();
+    });
+  });
+
+  it('should show prev & next when the active is the 2nd of 3', function() {
+    this.listeners.open(this.controller.slides[1]);
+    expectPrevToBeShown();
+    expectNextToBeShown();
+  });
+
+  describe('prev', function() {
+    it('should hide prev when non-circular and is the first slide', function() {
+      this.set({ isCircular: false });
+      this.listeners.open(this.controller.slides[0]);
+      expectPrevToBeHidden();
+    });
+
+    it('should not hide prev when circular and is the first slide', function() {
+      this.set({ isCircular: true });
+      this.listeners.open(this.controller.slides[0]);
+      expectPrevToBeShown();
+    });
+  });
+
+  describe('next', function() {
+    it('should hide next when non-circular and is the last slide', function() {
+      this.set({ isCircular: false });
+      this.listeners.open(this.controller.slides[2]);
+      expectNextToBeHidden();
+    });
+
+    it('should not hide prev when circular and is the last slide', function() {
+      this.set({ isCircular: true });
+      this.listeners.open(this.controller.slides[2]);
+      expectNextToBeShown();
+    });
+  });
+});

--- a/test/specs/Controller.js
+++ b/test/specs/Controller.js
@@ -54,23 +54,6 @@ describe('Controller', function() {
     });
   });
 
-  describe('hideExtras', function() {
-    it('should trigger an "extrasHidden" event', function(done) {
-      this.unit.on('extrasHidden', done);
-      this.unit.open(0);
-      this.unit.hideExtras();
-    });
-  });
-
-  describe('showExtras', function() {
-    it('should trigger an "extrasShown" event', function(done) {
-      this.unit.on('extrasShown', done);
-      this.unit.open(0);
-      this.unit.hideExtras();
-      this.unit.showExtras();
-    });
-  });
-
   describe('off', function() {
     it('should remove an event listener', function(done) {
       this.unit.on('open', () => done.fail('should have removed listener'));

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import lightbox from '../..';
 
 describe('lightbox', function() {
-  const FADE_TIME = 200;
+  const FADE_TIME = 5;
   const BLOCKING_CLASS = '.js-blocking';
   const LIGHTBOX_CLASS = '.js-lightbox';
   const NEXT_CLASS = '.js-next';


### PR DESCRIPTION
- (feature) hide prev/next controls as appropriate
- (feature) expose `.slides` and `.activeSlide`
- (breaking) move `(show|hide)Extras` to the view, as there may exist views that do not have a prev-next button (e.g., highlighted dots on the bottom)