### PR TITLE
Controller: send the previousSlide as the 2nd arg in the activate event

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 
 node_js:
-  - 4
   - 6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightbox",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Image lightbox",
   "main": "src",
   "scripts": {

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -14,6 +14,7 @@ export default class Controller {
     this._$links = this._$context.find(`:not(a) > ${this._props.slideSelector}`);
     this._hoverlisteners = [];
     this.slides = this._createSlides(this._$links);
+    this.activeSlide = void 0;
     this._isOpen = false;
     this._bind();
   }
@@ -41,6 +42,7 @@ export default class Controller {
   close() {
     this._isOpen = false;
     this.deactivateSlide(this.activeSlide);
+    this.activeSlide = void 0;
     this._trigger('close');
   }
 
@@ -62,8 +64,9 @@ export default class Controller {
 
   activateSlide(slide) {
     if (!slide) { return; }
+    const prevSlide = this.activeSlide;
     this.activeSlide = slide;
-    this._trigger('activate', slide);
+    this._trigger('activate', slide, prevSlide);
   }
 
   deactivateSlide(slide) {
@@ -101,7 +104,7 @@ export default class Controller {
       });
   }
 
-  _trigger(eventName, params) {
+  _trigger(eventName, ...params) {
     this._$eventNode.trigger(eventName, params);
   }
 

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -14,7 +14,6 @@ export default class Controller {
     this._$links = this._$context.find(`:not(a) > ${this._props.slideSelector}`);
     this._hoverlisteners = [];
     this.slides = this._createSlides(this._$links);
-    this.activeSlide = void 0;
     this._isOpen = false;
     this._bind();
   }
@@ -42,7 +41,7 @@ export default class Controller {
   close() {
     this._isOpen = false;
     this.deactivateSlide(this.activeSlide);
-    this.activeSlide = void 0;
+    delete this.activeSlide;
     this._trigger('close');
   }
 
@@ -66,7 +65,7 @@ export default class Controller {
     if (!slide) { return; }
     const prevSlide = this.activeSlide;
     this.activeSlide = slide;
-    this._trigger('activate', slide, prevSlide);
+    this._trigger('activate', [slide, prevSlide]);
   }
 
   deactivateSlide(slide) {
@@ -104,7 +103,7 @@ export default class Controller {
       });
   }
 
-  _trigger(eventName, ...params) {
+  _trigger(eventName, params) {
     this._$eventNode.trigger(eventName, params);
   }
 

--- a/test/specs/Controller.js
+++ b/test/specs/Controller.js
@@ -35,14 +35,19 @@ describe('Controller', function() {
       this.unit.on('close', done);
       this.unit.open(0);
       this.unit.close();
+      expect(this.unit.activeSlide).not.toBeDefined();
     });
   });
 
   describe('next', function() {
     it('should trigger a "activate" event', function(done) {
-      this.unit.on('activate', (slide) => {
-        if (slide.id === 0) { return; }
+      this.unit.on('activate', (slide, prevSlide) => {
+        if (slide.id === 0) {
+          expect(prevSlide).not.toBeDefined();
+          return;
+        }
         expect(slide.id).toBe(1);
+        expect(prevSlide.id).toBe(0);
         done();
       });
       this.unit.open(0);
@@ -52,9 +57,13 @@ describe('Controller', function() {
 
   describe('prev', function() {
     it('should trigger a "prev" event', function(done) {
-      this.unit.on('activate', (slide) => {
-        if (slide.id === 1) { return; }
+      this.unit.on('activate', (slide, prevSlide) => {
+        if (slide.id === 1) {
+          expect(prevSlide).not.toBeDefined();
+          return;
+        }
         expect(slide.id).toBe(0);
+        expect(prevSlide.id).toBe(1);
         done();
       });
       this.unit.open(1);


### PR DESCRIPTION
One use case is to determine the direction (e.g., `const isRight = (prevSlide.id < activeSlide.id);`) 