### PR TITLE
Feature: support disabling pre-fetching of certain slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A component, which opens an image or a set of images in their own scrollable view with the goal of removing distractions from the page.
 
+### Cutting a Release
+
+ 1. Before cutting a new release, make sure your changes are *merged*, your *master* branch is *up to date (pull from upstream)*, and you're on your *`master`* branch.
+ 2. To create a new release, use `npm version major`, `npm version minor`, or `npm version patch` to update package.json and create a release commit and git version tag.
+ 3. Finally, use `git push upstream master --tags` (assuming your `upstream` is pointed at behance/lightbox) to push the version commit and tags to the repo.
+ 4. Run `npm publish --access public`
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lightbox",
+  "name": "@behance/lightbox",
   "version": "9.0.0",
   "description": "Image lightbox",
   "main": "src",

--- a/src/ChromeView.js
+++ b/src/ChromeView.js
@@ -169,8 +169,12 @@ export default class ChromeView {
     this._$view.removeClass(EXTRAS_HIDDEN_CLASS);
   }
 
-  _appendSlide(slide) {
-    if (!slide || this._$contents.find(`[data-slide-id="${slide.id}"]`).length) { return; }
+  _appendSlide(slide, { isPrefetch } = {}) {
+    if (!slide ||
+        this._$contents.find(`[data-slide-id="${slide.id}"]`).length ||
+        (isPrefetch && slide.data.noPrefetch)) {
+      return;
+    }
 
     const $content = $('<div>')
       .addClass(`${JS_SLIDE_CONTENT_CLASS} ${CONTENT_CLASS} ${HIDDEN_CLASS}`)
@@ -183,14 +187,16 @@ export default class ChromeView {
 
 
   _appendAdjacentSlides($current, $new) {
+    const appendOptions = { isPrefetch: true };
     if ($current.length === 0) {
-      this._appendSlide(this._controller.getPrevSlide());
-      this._appendSlide(this._controller.getNextSlide());
+      this._appendSlide(this._controller.getPrevSlide(), appendOptions);
+      this._appendSlide(this._controller.getNextSlide(), appendOptions);
     }
     else {
       this._appendSlide($current.data('slide-id') < $new.data('slide-id')
         ? this._controller.getNextSlide()
-        : this._controller.getPrevSlide());
+        : this._controller.getPrevSlide(),
+        appendOptions);
     }
   }
 
@@ -200,7 +206,7 @@ export default class ChromeView {
       close: () => this.close(),
       destroy: () => this.destroy(),
       activate: slide => this.renderSlide(slide),
-      prefetch: slide => this._appendSlide(slide)
+      prefetch: slide => this._appendSlide(slide, { isPrefetch: true })
     });
   }
 

--- a/test/specs/ChromeView.js
+++ b/test/specs/ChromeView.js
@@ -12,10 +12,12 @@ const CHROME_WRAP_CLASS = '.js-lightbox-wrap';
 const PREV_CLASS = '.js-prev';
 const NEXT_CLASS = '.js-next';
 const HIDDEN_CLASS = 'hidden';
+const OFFSCREEN_CLASS = 'offscreen';
 const expectPrevToBeHidden = () => expect($(PREV_CLASS)).toHaveClass(HIDDEN_CLASS);
 const expectPrevToBeShown = () => expect($(PREV_CLASS)).not.toHaveClass(HIDDEN_CLASS);
 const expectNextToBeHidden = () => expect($(NEXT_CLASS)).toHaveClass(HIDDEN_CLASS);
 const expectNextToBeShown = () => expect($(NEXT_CLASS)).not.toHaveClass(HIDDEN_CLASS);
+const expectToBeOffscreen = ($el) => expect($el).toHaveClass(OFFSCREEN_CLASS);
 
 describe('ChromeView', function() {
   beforeEach(function() {
@@ -37,6 +39,8 @@ describe('ChromeView', function() {
       this.listeners = this.controller.on.calls.first().args[0];
     };
     this.set({ imageSrcDataAttr: 'src' });
+    this.$findSlide = id => $(`.js-slide[data-slide-id="${id}"]`);
+    this.$findSlideContent = id => this.$findSlide(id).find('.js-slide-content');
   });
 
   afterEach(function() {
@@ -133,8 +137,6 @@ describe('ChromeView', function() {
   describe('renderSlide', function() {
     beforeEach(function() {
       this.view.open();
-      this.$findSlide = id => $(`.js-slide[data-slide-id="${id}"]`);
-      this.$findSlideContent = id => this.$findSlide(id).find('.js-slide-content');
     });
 
     it('should remove the current slide after slide out transition', function() {
@@ -160,6 +162,24 @@ describe('ChromeView', function() {
       this.view.renderSlide(slides[0]);
       this.$findSlideContent(0).trigger('transitionend');
       expect(this.$findSlide(0)).toBeInDOM();
+    });
+  });
+
+  describe('prefetch', function() {
+    it('should append a slide without rendering it', function() {
+      this.listeners.prefetch(this.controller.slides[0]);
+      const $slide = this.$findSlide(0);
+      expect($slide).toBeInDOM();
+      expectToBeOffscreen($slide);
+    });
+
+    it('should not append a slide with data-no-prefetch="true"', function() {
+      this.listeners.prefetch({
+        ...this.controller.slides[0],
+        data: { noPrefetch: true },
+      });
+      const $slide = this.$findSlide(0);
+      expect($slide).not.toBeInDOM();
     });
   });
 });


### PR DESCRIPTION
Allow the client to disable prefetching for certain slides. This is useful for when you need to have an auto-played video in a slide. You don't want it to start playing in the background when pre-fetching.